### PR TITLE
Add as prop in Text component on PricingCard

### DIFF
--- a/components/library/PricingCard/Preview/PricingCard.jsx
+++ b/components/library/PricingCard/Preview/PricingCard.jsx
@@ -36,7 +36,7 @@ export const PricingCard = ({ title, description, price, features, featuredText,
               {price}
             </Text>
             <Box paddingBlockEnd="200">
-              <Text variant="bodySm">/ {frequency}</Text>
+              <Text as="p" variant="bodySm">/ {frequency}</Text>
             </Box>
           </InlineStack>
 


### PR DESCRIPTION
## Motivation

`as` prop is required in [Text](https://polaris.shopify.com/components/typography/text) component.